### PR TITLE
Composer parser crashes in no-interaction mode

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -175,8 +175,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             function ($input) {
                 $input = trim($input);
                 return $input ?: false;
-            }
-        , null, false);
+            },
+            null,
+            false
+        );
 
         if ($constraint === false) {
             $constraint = $this->findBestVersionForPackage($name);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -176,7 +176,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 $input = trim($input);
                 return $input ?: false;
             }
-        );
+        , null, false);
 
         if ($constraint === false) {
             $constraint = $this->findBestVersionForPackage($name);

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -261,7 +261,9 @@ class PluginTest extends TestCase
         $this->io->askAndValidate(
             'Enter the version of <info>extra-dependency-foo</info> to require'
                 . ' (or leave blank to use the latest version): ',
-            Argument::type('callable')
+            Argument::type('callable'),
+            null,
+            false
         )->willReturn('17.0.1-dev');
 
         $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
@@ -334,7 +336,9 @@ class PluginTest extends TestCase
         $this->io->askAndValidate(
             'Enter the version of <info>extra-dependency-foo</info> to require'
                 . ' (or leave blank to use the latest version): ',
-            Argument::type('callable')
+            Argument::type('callable'),
+            null,
+            false
         )->willReturn('17.0.1-dev');
 
         $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
@@ -415,7 +419,9 @@ class PluginTest extends TestCase
         $this->io->askAndValidate(
             'Enter the version of <info>extra-dependency-foo</info> to require'
                 . ' (or leave blank to use the latest version): ',
-            Argument::type('callable')
+            Argument::type('callable'),
+            null,
+            false
         )->willReturn('17.0.1-dev');
 
         $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
@@ -494,7 +500,9 @@ class PluginTest extends TestCase
         $this->io->askAndValidate(
             'Enter the version of <info>extra-dependency-foo</info> to require'
                 . ' (or leave blank to use the latest version): ',
-            Argument::type('callable')
+            Argument::type('callable'),
+            null,
+            false
         )->willReturn(false);
 
         $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
@@ -558,7 +566,9 @@ class PluginTest extends TestCase
         $this->io->askAndValidate(
             'Enter the version of <info>extra-dependency-foo</info> to require'
                 . ' (or leave blank to use the latest version): ',
-            Argument::type('callable')
+            Argument::type('callable'),
+            null,
+            false
         )->willReturn(false);
 
         $this->setUpComposerJson();


### PR DESCRIPTION
If this module is required as a sub-dependency (e.g. an own module requiring your [http-middleware-compatibility](https://github.com/webimpress/http-middleware-compatibility) module) which does not require the module in question, composer-extra-dependency adds the following line to the composer.json in --no-interaction-mode:
```"http-interop/http-middleware": null```
which causes Composer's version parser to fail: 
```
[UnexpectedValueException]                                      
Could not parse version constraint : Invalid version string ""
```

This pr adds a default value to IOInterface:askAndValidate in order to fall back to the latest versio in no-interaction-mode (which basically behaves the same as leaving the question unanswered in interaction-mode). I am well aware that this can lead to conflicts, as the implementation might not match the latest version yet. On the other hand considering that non-interactive update-calls are mostly done in automated environments, I would rather appreciate an error message that points to the parts where I violate against the latest version rather than the error message posted above. I would need to add an additional version constraint for the particular packages anyway if my implementation does not match the latest implementation.

Minimum composer.json to reproduce the problem:
```
{
    "name": "test/test",
    "license": "BSD-2-Clause",
    "keywords": [
        "webimpress",
        "psr-15",
        "middleware"
    ],
    "require": {
        "php": "^5.6 || ^7.0",
        "webimpress/http-middleware-compatibility": "0.1.3"
    }
}
```

Just run composer update --no-interaction.