### PR TITLE
Use '*' as constraint in no-interaction mode

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -178,6 +178,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             }
         );
 
+        // value provided by user or bool false if empty
         if ($constraint === false) {
             $constraint = $this->findBestVersionForPackage($name);
             $this->io->write(sprintf(
@@ -185,6 +186,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 $constraint,
                 $name
             ));
+        } elseif ($constraint === null) {
+            // when no-interaction mode is enabled - default value: null
+            $constraint = '*';
         }
 
         return $constraint;


### PR DESCRIPTION
Please see #3 

This is another solution to use `*` in no-interaction mode. This resolve issue if another package requires the package in specific version, then the version will be handled instead of the latest one.

/cc @wearethewinds  
Closes #3 