### PR TITLE
Added functionality to choose one dependency from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,18 @@ you'd like to install with your library:
         "dependency": [
             "package/to-require",
             ...
-        ]
+        ],
+        "dependency-or": {
+            "Question": [
+                "package/to-choose",
+                "package/or-this",
+                ...
+            ]
+        }
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "webimpress/composer-extra-dependency": "^0.1 || ^1.0",
+        "webimpress/composer-extra-dependency": "^0.3 || ^1.0",
         ...
     }
     ...  

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -22,6 +22,7 @@ use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
 use Composer\Script\Event;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Plugin implements PluginInterface, EventSubscriberInterface
@@ -386,7 +387,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $package = $versionSelector->findBestCandidate($name, null, null, 'stable');
 
         if (! $package) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Could not find package %s at any version for your minimum-stability (%s).'
                     . ' Check the package spelling or your minimum-stability',
                 $name,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -21,6 +21,7 @@ use Composer\Plugin\PluginInterface;
 use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
+use RuntimeException;
 
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
@@ -63,7 +64,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         $installedPackages = $this->composer->getRepositoryManager()->getLocalRepository()->getPackages();
         foreach ($installedPackages as $package) {
-            $this->installedPackages[$package->getName()] = $package->getPrettyVersion();
+            $this->installedPackages[strtolower($package->getName())] = $package->getPrettyVersion();
         }
     }
 
@@ -85,23 +86,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         } else {
             $package = $operation->getTargetPackage();
         }
-        $extra = $this->getExtraMetadata($package->getExtra());
-        if (empty($extra)) {
-            // Package does not define anything of interest; do nothing.
-            return;
-        }
 
-        $packages = array_flip($extra);
-
-        foreach ($packages as $package => &$constraint) {
-            if ($this->hasPackage($package)) {
-                unset($packages[$package]);
-                continue;
-            }
-
-            $constraint = $this->promptForPackageVersion($package);
-        }
-
+        $extra = $package->getExtra();
+        $packages = $this->andDependencies($extra) + $this->orDependencies($extra);
         if ($packages) {
             $this->updateComposerJson($packages);
 
@@ -110,11 +97,72 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    private function getExtraMetadata(array $extra)
+    private function andDependencies(array $extra)
     {
-        return isset($extra['dependency']) && is_array($extra['dependency'])
+        $deps = isset($extra['dependency']) && is_array($extra['dependency'])
             ? $extra['dependency']
             : [];
+
+        if (! $deps) {
+            // No defined any packages to install
+            return [];
+        }
+
+        $packages = array_flip($deps);
+
+        foreach ($packages as $package => &$constraint) {
+            if ($this->hasPackage($package)) {
+                unset($packages[$package]);
+                continue;
+            }
+
+            // Check if package is currently installed and use installed version.
+            if ($constraint = $this->getInstalledPackageConstraint($package)) {
+                continue;
+            }
+
+            // Package is not installed, then prompt user for the version.
+            $constraint = $this->promptForPackageVersion($package);
+        }
+
+        return $packages;
+    }
+
+    private function orDependencies(array $extra)
+    {
+        $deps = isset($extra['dependency-or']) && is_array($extra['dependency-or'])
+            ? $extra['dependency-or']
+            : [];
+
+        if (! $deps) {
+            // No any dependencies to choose defined in the package.
+            return [];
+        }
+
+        $packages = [];
+        foreach ($deps as $question => $options) {
+            if (! is_array($options) || count($options) < 2) {
+                throw new RuntimeException('You must provide at least two optional dependencies.');
+            }
+
+            foreach ($options as $package) {
+                if ($this->hasPackage($package)) {
+                    // Package from this group has been found in root composer, skipping.
+                    continue 2;
+                }
+
+                // Check if package is currently installed, if so, use installed constraint and skip question.
+                if ($constraint = $this->getInstalledPackageConstraint($package)) {
+                    $packages[$package] = $constraint;
+                    continue 2;
+                }
+            }
+
+            $package = $this->promptForPackageSelection($question, $options);
+            $packages[$package] = $this->promptForPackageVersion($package);
+        }
+
+        return $packages;
     }
 
     private function updateRootPackage(RootPackageInterface $rootPackage, array $packages)
@@ -157,21 +205,54 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         return $installer->run();
     }
 
-    private function promptForPackageVersion($name)
+    private function getInstalledPackageConstraint($package)
     {
-        // Package is currently installed. Add it to root composer.json
-        if (isset($this->installedPackages[$name])) {
-            $this->io->write(sprintf(
-                'Added package <info>%s</info> to composer.json with constraint <info>%s</info>;'
-                    . ' to upgrade, run <info>composer require %s:VERSION</info>',
-                $name,
-                '^' . $this->installedPackages[$name],
-                $name
-            ));
+        $lower = strtolower($package);
 
-            return '^' . $this->installedPackages[$name];
+        // Package is currently installed. Add it to root composer.json
+        if (! isset($this->installedPackages[$lower])) {
+            return null;
         }
 
+        $constraint = '^' . $this->installedPackages[$lower];
+        $this->io->write(sprintf(
+            'Added package <info>%s</info> to composer.json with constraint <info>%s</info>;'
+            . ' to upgrade, run <info>composer require %s:VERSION</info>',
+            $package,
+            $constraint,
+            $package
+        ));
+
+        return $constraint;
+    }
+
+    private function promptForPackageSelection($question, array $packages)
+    {
+        $ask = [sprintf('<question>%s</question>', $question)];
+        foreach ($packages as $i => $name) {
+            $ask[] = sprintf('[<comment>%d</comment>] %s', $i + 1, $name);
+        }
+
+        do {
+            $package = $this->io->askAndValidate(
+                $ask,
+                function ($input) use ($packages) {
+                    $input = is_numeric($input) ? (int) trim($input) : 0;
+
+                    if (isset($packages[$input - 1])) {
+                        return $packages[$input - 1];
+                    }
+
+                    return null;
+                }
+            );
+        } while (! $package);
+
+        return $package;
+    }
+
+    private function promptForPackageVersion($name)
+    {
         $constraint = $this->io->askAndValidate(
             sprintf(
                 'Enter the version of <info>%s</info> to require (or leave blank to use the latest version): ',

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -228,10 +228,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
     private function promptForPackageSelection($question, array $packages)
     {
-        $ask = [sprintf('<question>%s</question>', $question)];
+        $ask = [sprintf('<question>%s</question>' . "\n", $question)];
         foreach ($packages as $i => $name) {
-            $ask[] = sprintf('[<comment>%d</comment>] %s', $i + 1, $name);
+            $ask[] = sprintf('  [<comment>%d</comment>] %s' . "\n", $i + 1, $name);
         }
+        $ask[] = '  Make your selection: ';
 
         do {
             $package = $this->io->askAndValidate(

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -717,10 +717,11 @@ class PluginTest extends TestCase
                         return false;
                     }
 
-                    Assert::assertCount(3, $arg);
-                    Assert::assertSame('<question>My question foo bar baz</question>', $arg[0]);
-                    Assert::assertSame('[<comment>1</comment>] extra-dependency-foo', $arg[1]);
-                    Assert::assertSame('[<comment>2</comment>] extra-dependency-bar', $arg[2]);
+                    Assert::assertCount(4, $arg);
+                    Assert::assertSame('<question>My question foo bar baz</question>' . "\n", $arg[0]);
+                    Assert::assertSame('  [<comment>1</comment>] extra-dependency-foo' . "\n", $arg[1]);
+                    Assert::assertSame('  [<comment>2</comment>] extra-dependency-bar' . "\n", $arg[2]);
+                    Assert::assertSame('  Make your selection: ', $arg[3]);
 
                     return true;
                 }),
@@ -1016,11 +1017,12 @@ class PluginTest extends TestCase
                         return false;
                     }
 
-                    Assert::assertCount(4, $arg);
-                    Assert::assertSame('<question>Choose something</question>', $arg[0]);
-                    Assert::assertSame('[<comment>1</comment>] extra-choose-one', $arg[1]);
-                    Assert::assertSame('[<comment>2</comment>] extra-choose-two', $arg[2]);
-                    Assert::assertSame('[<comment>3</comment>] extra-choose-three', $arg[3]);
+                    Assert::assertCount(5, $arg);
+                    Assert::assertSame('<question>Choose something</question>' . "\n", $arg[0]);
+                    Assert::assertSame('  [<comment>1</comment>] extra-choose-one' . "\n", $arg[1]);
+                    Assert::assertSame('  [<comment>2</comment>] extra-choose-two' . "\n", $arg[2]);
+                    Assert::assertSame('  [<comment>3</comment>] extra-choose-three' . "\n", $arg[3]);
+                    Assert::assertSame('  Make your selection: ', $arg[4]);
 
                     return true;
                 }),

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -19,6 +19,7 @@ use Composer\Package\RootPackageInterface;
 use Composer\Package\Version\VersionSelector;
 use Composer\Repository\RepositoryManager;
 use Composer\Repository\WritableRepositoryInterface;
+use Composer\Script\Event;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -144,9 +145,21 @@ class PluginTest extends TestCase
         $subscribers = Plugin::getSubscribedEvents();
         $this->assertArrayHasKey('post-package-install', $subscribers);
         $this->assertArrayHasKey('post-package-update', $subscribers);
+        $this->assertArrayHasKey('post-install-cmd', $subscribers);
+        $this->assertArrayHasKey('post-update-cmd', $subscribers);
 
         $this->assertEquals('onPostPackage', $subscribers['post-package-install']);
         $this->assertEquals('onPostPackage', $subscribers['post-package-update']);
+        $this->assertEquals('onPostCommand', $subscribers['post-install-cmd']);
+        $this->assertEquals('onPostCommand', $subscribers['post-update-cmd']);
+    }
+
+    private function getCommandEvent($isDevMode = true)
+    {
+        $event = $this->prophesize(Event::class);
+        $event->isDevMode()->willReturn($isDevMode);
+
+        return $event->reveal();
     }
 
     public function testDoNothingIfItIsNotInDevMode()
@@ -155,6 +168,7 @@ class PluginTest extends TestCase
         $event->isDevMode()->willReturn(false);
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent(false)));
     }
 
     public function testDoNothingInNoInteractionMode()
@@ -184,6 +198,7 @@ class PluginTest extends TestCase
         $this->io->isInteractive()->willReturn(false);
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
     }
 
     public function testDoNothingWhenThereIsNoExtraDependencies()
@@ -201,6 +216,7 @@ class PluginTest extends TestCase
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
     }
 
     public function testDependencyAlreadyIsInRequiredSection()
@@ -230,6 +246,7 @@ class PluginTest extends TestCase
         $this->composer->getPackage()->willReturn($rootPackage);
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
     }
 
     public function testDependencyAlreadyIsInRequiredDevSection()
@@ -263,6 +280,7 @@ class PluginTest extends TestCase
         $this->composer->getPackage()->willReturn($rootPackage);
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
     }
 
     public function testInstallSingleDependencyOnPackageUpdate()
@@ -337,6 +355,7 @@ class PluginTest extends TestCase
         $this->setUpComposerJson();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
     }
 
     public function testInstallSingleDependencyOnPackageInstall()
@@ -394,6 +413,7 @@ class PluginTest extends TestCase
         $this->setUpComposerJson();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
     }
 
     public function testInstallOneDependenciesWhenOneIsAlreadyInstalled()
@@ -459,6 +479,7 @@ class PluginTest extends TestCase
         $this->setUpComposerJson();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
 
         $json = file_get_contents(vfsStream::url('project/composer.json'));
         $composer = json_decode($json, true);
@@ -536,6 +557,7 @@ class PluginTest extends TestCase
         $this->setUpPool();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
 
         $json = file_get_contents(vfsStream::url('project/composer.json'));
         $composer = json_decode($json, true);
@@ -658,6 +680,7 @@ class PluginTest extends TestCase
         $this->setUpComposerJson();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
 
         $json = file_get_contents(vfsStream::url('project/composer.json'));
         $composer = json_decode($json, true);
@@ -782,6 +805,7 @@ class PluginTest extends TestCase
         $this->setUpPool();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
 
         $json = file_get_contents(vfsStream::url('project/composer.json'));
         $composer = json_decode($json, true);
@@ -860,6 +884,7 @@ class PluginTest extends TestCase
         $this->setUpPool();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
 
         $json = file_get_contents(vfsStream::url('project/composer.json'));
         $composer = json_decode($json, true);
@@ -1071,6 +1096,7 @@ class PluginTest extends TestCase
         $this->setUpPool();
 
         $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+        $this->assertNull($this->plugin->onPostCommand($this->getCommandEvent()));
 
         $json = file_get_contents(vfsStream::url('project/composer.json'));
         $composer = json_decode($json, true);

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -20,11 +20,13 @@ use Composer\Package\Version\VersionSelector;
 use Composer\Repository\RepositoryManager;
 use Composer\Repository\WritableRepositoryInterface;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
 use ReflectionProperty;
+use RuntimeException;
 use Webimpress\ComposerExtraDependency\Plugin;
 
 class PluginTest extends TestCase
@@ -291,30 +293,12 @@ class PluginTest extends TestCase
         $rootPackage = $this->prophesize(RootPackageInterface::class);
         $rootPackage->getRequires()->willReturn([]);
         $rootPackage->getDevRequires()->willReturn([]);
-        $rootPackage->setRequires(Argument::that(function ($arguments) {
-            if (! is_array($arguments)) {
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 1) {
                 return false;
             }
 
-            if (! isset($arguments['extra-dependency-foo'])) {
-                return false;
-            }
-
-            $argument = $arguments['extra-dependency-foo'];
-
-            if (! $argument instanceof Link) {
-                return false;
-            }
-
-            if ($argument->getTarget() !== 'extra-dependency-foo') {
-                return false;
-            }
-
-            if ($argument->getConstraint()->getPrettyString() !== '17.0.1-dev') {
-                return false;
-            }
-
-            if ($argument->getDescription() !== 'requires') {
+            if (! $this->assertSetRequiresArgument('extra-dependency-foo', '17.0.1-dev', $arguments)) {
                 return false;
             }
 
@@ -328,7 +312,21 @@ class PluginTest extends TestCase
         $this->io->askAndValidate(
             'Enter the version of <info>extra-dependency-foo</info> to require'
                 . ' (or leave blank to use the latest version): ',
-            Argument::type('callable')
+            Argument::that(function ($arg) {
+                if (! is_callable($arg)) {
+                    return false;
+                }
+
+                Assert::assertFalse($arg(0));
+                Assert::assertFalse($arg('0'));
+                Assert::assertFalse($arg(''));
+                Assert::assertFalse($arg(' '));
+                Assert::assertSame('1', $arg('  1 '));
+                Assert::assertSame('1', $arg('1'));
+                Assert::assertSame('0.*', $arg('0.*'));
+
+                return true;
+            })
         )->willReturn('17.0.1-dev');
 
         $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
@@ -366,30 +364,12 @@ class PluginTest extends TestCase
         $rootPackage = $this->prophesize(RootPackageInterface::class);
         $rootPackage->getRequires()->willReturn([]);
         $rootPackage->getDevRequires()->willReturn([]);
-        $rootPackage->setRequires(Argument::that(function ($arguments) {
-            if (! is_array($arguments)) {
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 1) {
                 return false;
             }
 
-            if (! isset($arguments['extra-dependency-foo'])) {
-                return false;
-            }
-
-            $argument = $arguments['extra-dependency-foo'];
-
-            if (! $argument instanceof Link) {
-                return false;
-            }
-
-            if ($argument->getTarget() !== 'extra-dependency-foo') {
-                return false;
-            }
-
-            if ($argument->getConstraint()->getPrettyString() !== '17.0.1-dev') {
-                return false;
-            }
-
-            if ($argument->getDescription() !== 'requires') {
+            if (! $this->assertSetRequiresArgument('extra-dependency-foo', '17.0.1-dev', $arguments)) {
                 return false;
             }
 
@@ -445,34 +425,16 @@ class PluginTest extends TestCase
         $rootPackage = $this->prophesize(RootPackageInterface::class);
         $rootPackage->getRequires()->willReturn(['extra-dependency-bar' => $link->reveal()]);
         $rootPackage->getDevRequires()->willReturn([]);
-        $rootPackage->setRequires(Argument::that(function ($arguments) {
-            if (! is_array($arguments)) {
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 2) {
                 return false;
             }
 
-            if (! isset($arguments['extra-dependency-foo'])) {
+            if (! $this->assertSetRequiresArgument('extra-dependency-foo', '17.0.1-dev', $arguments)) {
                 return false;
             }
 
             if (! isset($arguments['extra-dependency-bar'])) {
-                return false;
-            }
-
-            $argument = $arguments['extra-dependency-foo'];
-
-            if (! $argument instanceof Link) {
-                return false;
-            }
-
-            if ($argument->getTarget() !== 'extra-dependency-foo') {
-                return false;
-            }
-
-            if ($argument->getConstraint()->getPrettyString() !== '17.0.1-dev') {
-                return false;
-            }
-
-            if ($argument->getDescription() !== 'requires') {
                 return false;
             }
 
@@ -529,30 +491,12 @@ class PluginTest extends TestCase
         $rootPackage = $this->prophesize(RootPackageInterface::class);
         $rootPackage->getRequires()->willReturn([]);
         $rootPackage->getDevRequires()->willReturn([]);
-        $rootPackage->setRequires(Argument::that(function ($arguments) {
-            if (! is_array($arguments)) {
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 1) {
                 return false;
             }
 
-            if (! isset($arguments['extra-dependency-foo'])) {
-                return false;
-            }
-
-            $argument = $arguments['extra-dependency-foo'];
-
-            if (! $argument instanceof Link) {
-                return false;
-            }
-
-            if ($argument->getTarget() !== 'extra-dependency-foo') {
-                return false;
-            }
-
-            if ($argument->getConstraint()->getPrettyString() !== '13.4.2') {
-                return false;
-            }
-
-            if ($argument->getDescription() !== 'requires') {
+            if (! $this->assertSetRequiresArgument('extra-dependency-foo', '13.4.2', $arguments)) {
                 return false;
             }
 
@@ -683,30 +627,12 @@ class PluginTest extends TestCase
         $rootPackage = $this->prophesize(RootPackageInterface::class);
         $rootPackage->getRequires()->willReturn([]);
         $rootPackage->getDevRequires()->willReturn([]);
-        $rootPackage->setRequires(Argument::that(function ($arguments) {
-            if (! is_array($arguments)) {
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 1) {
                 return false;
             }
 
-            if (! isset($arguments['extra-dependency-foo'])) {
-                return false;
-            }
-
-            $argument = $arguments['extra-dependency-foo'];
-
-            if (! $argument instanceof Link) {
-                return false;
-            }
-
-            if ($argument->getTarget() !== 'extra-dependency-foo') {
-                return false;
-            }
-
-            if ($argument->getConstraint()->getPrettyString() !== '^0.5.1') {
-                return false;
-            }
-
-            if ($argument->getDescription() !== 'requires') {
+            if (! $this->assertSetRequiresArgument('extra-dependency-foo', '^0.5.1', $arguments)) {
                 return false;
             }
 
@@ -721,7 +647,7 @@ class PluginTest extends TestCase
         $this->io
             ->write(
                 'Added package <info>extra-dependency-foo</info> to composer.json with constraint'
-                . ' <info>^0.5.1</info>; to upgrade, run <info>composer require extra-dependency-foo:VERSION</info>'
+                    . ' <info>^0.5.1</info>; to upgrade, run <info>composer require extra-dependency-foo:VERSION</info>'
             )
             ->shouldBeCalled();
         $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
@@ -737,6 +663,446 @@ class PluginTest extends TestCase
         $composer = json_decode($json, true);
         $this->assertTrue(isset($composer['require']['extra-dependency-foo']));
         $this->assertSame('^0.5.1', $composer['require']['extra-dependency-foo']);
+    }
+
+    public function testDependencyOrChoosePackageToInstall()
+    {
+        /** @var PackageInterface|ObjectProphecy $package */
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/component');
+        $package->getExtra()->willReturn([
+            'dependency-or' => [
+                'My question foo bar baz' => [
+                    'extra-dependency-foo',
+                    'extra-dependency-bar',
+                ],
+            ],
+        ]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $config = $this->prophesize(Config::class);
+        $config->get('sort-packages')->willReturn(true);
+        $config->get(Argument::any())->willReturn(null);
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $rootPackage->getRequires()->willReturn([]);
+        $rootPackage->getDevRequires()->willReturn([]);
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 1) {
+                return false;
+            }
+
+            if (! $this->assertSetRequiresArgument('extra-dependency-bar', '13.4.2', $arguments)) {
+                return false;
+            }
+
+            return true;
+        }))->shouldBeCalled();
+        $rootPackage->getMinimumStability()->willReturn('stable');
+
+        $this->composer->getPackage()->willReturn($rootPackage);
+        $this->composer->getConfig()->willReturn($config->reveal());
+
+        $this->io->isInteractive()->willReturn(true);
+        $this->io
+            ->askAndValidate(
+                Argument::that(function ($arg) {
+                    if (! is_array($arg)) {
+                        return false;
+                    }
+
+                    Assert::assertCount(3, $arg);
+                    Assert::assertSame('<question>My question foo bar baz</question>', $arg[0]);
+                    Assert::assertSame('[<comment>1</comment>] extra-dependency-foo', $arg[1]);
+                    Assert::assertSame('[<comment>2</comment>] extra-dependency-bar', $arg[2]);
+
+                    return true;
+                }),
+                Argument::that(function ($arg) {
+                    if (! is_callable($arg)) {
+                        return false;
+                    }
+
+                    Assert::assertSame('extra-dependency-foo', $arg(1));
+                    Assert::assertSame('extra-dependency-foo', $arg('1'));
+                    Assert::assertSame('extra-dependency-foo', $arg(' 1'));
+                    Assert::assertSame('extra-dependency-foo', $arg('1.0'));
+                    Assert::assertSame('extra-dependency-bar', $arg(2));
+                    Assert::assertSame('extra-dependency-bar', $arg('2'));
+                    Assert::assertSame('extra-dependency-bar', $arg(' 2'));
+                    Assert::assertSame('extra-dependency-bar', $arg('2.2'));
+                    Assert::assertNull($arg(''));
+                    Assert::assertNull($arg(' '));
+                    Assert::assertNull($arg('a'));
+                    Assert::assertNull($arg('1a'));
+                    Assert::assertNull($arg(' a'));
+                    Assert::assertNull($arg(0));
+                    Assert::assertNull($arg(3));
+
+                    return true;
+                })
+            )
+            ->willReturn('', 'extra-dependency-bar')
+            ->shouldBeCalledTimes(2);
+        $this->io
+            ->askAndValidate(
+                'Enter the version of <info>extra-dependency-bar</info> to require'
+                    . ' (or leave blank to use the latest version): ',
+                Argument::type('callable')
+            )
+            ->willReturn(false)
+            ->shouldBeCalledTimes(1);
+
+        $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
+        $this->io->write('<info>Updating root package</info>')->shouldBeCalled();
+        $this->io->write('<info>    Running an update to install dependent packages</info>')->shouldBeCalled();
+        $this->io->write('Using version <info>13.4.2</info> for <info>extra-dependency-bar</info>')->shouldBeCalled();
+
+        $this->setUpComposerInstaller(['extra-dependency-bar']);
+        $this->setUpComposerJson();
+
+        $package = $this->prophesize(PackageInterface::class);
+
+        $versionSelector = $this->prophesize(VersionSelector::class);
+        $versionSelector->findBestCandidate('extra-dependency-bar', null, null, 'stable')
+            ->willReturn($package->reveal())
+            ->shouldBeCalled();
+        $versionSelector->findRecommendedRequireVersion($package->reveal())
+            ->willReturn('13.4.2')
+            ->shouldBeCalled();
+
+        $this->setUpVersionSelector($versionSelector->reveal());
+        $this->setUpPool();
+
+        $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+
+        $json = file_get_contents(vfsStream::url('project/composer.json'));
+        $composer = json_decode($json, true);
+        $this->assertTrue(isset($composer['require']['extra-dependency-bar']));
+        $this->assertSame('13.4.2', $composer['require']['extra-dependency-bar']);
+    }
+
+    public function testDependencyOrOnePackageIsAlreadyInstalledAndShouldBeAddedIntoRootComposer()
+    {
+        $installedPackage = $this->prophesize(PackageInterface::class);
+        $installedPackage->getName()->willReturn('extra-dependency-baz');
+        $installedPackage->getPrettyVersion()->willReturn('3.7.1');
+
+        $this->localRepository->getPackages()->willReturn([$installedPackage->reveal()]);
+        $this->plugin->activate($this->composer->reveal(), $this->io->reveal());
+
+        /** @var PackageInterface|ObjectProphecy $package */
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/component');
+        $package->getExtra()->willReturn([
+            'dependency-or' => [
+                'Choose something' => [
+                    'extra-dependency-bar',
+                    'extra-dependency-baz',
+                ],
+            ],
+        ]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $config = $this->prophesize(Config::class);
+        $config->get('sort-packages')->willReturn(true);
+        $config->get(Argument::any())->willReturn(null);
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $rootPackage->getRequires()->willReturn([]);
+        $rootPackage->getDevRequires()->willReturn([]);
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 1) {
+                return false;
+            }
+
+            if (! $this->assertSetRequiresArgument('extra-dependency-baz', '^3.7.1', $arguments)) {
+                return false;
+            }
+
+            return true;
+        }))->shouldBeCalled();
+        $rootPackage->getMinimumStability()->willReturn('stable');
+
+        $this->composer->getPackage()->willReturn($rootPackage);
+        $this->composer->getConfig()->willReturn($config->reveal());
+
+        $this->io->isInteractive()->willReturn(true);
+        $this->io
+            ->write(
+                'Added package <info>extra-dependency-baz</info> to composer.json with constraint'
+                    . ' <info>^3.7.1</info>; to upgrade, run <info>composer require extra-dependency-baz:VERSION</info>'
+            )
+            ->shouldBeCalled();
+        $this->io
+            ->askAndValidate(Argument::any(), Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
+        $this->io->write('<info>Updating root package</info>')->shouldBeCalled();
+        $this->io->write('<info>    Running an update to install dependent packages</info>')->shouldBeCalled();
+
+        $this->setUpComposerInstaller(['extra-dependency-baz']);
+        $this->setUpComposerJson();
+        $this->setUpPool();
+
+        $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+
+        $json = file_get_contents(vfsStream::url('project/composer.json'));
+        $composer = json_decode($json, true);
+        $this->assertTrue(isset($composer['require']['extra-dependency-baz']));
+        $this->assertSame('^3.7.1', $composer['require']['extra-dependency-baz']);
+    }
+
+    public function testDependencyOrOnePackageIsAlreadyInRootComposer()
+    {
+        /** @var PackageInterface|ObjectProphecy $package */
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/component');
+        $package->getExtra()->willReturn([
+            'dependency-or' => [
+                'Choose something' => [
+                    'extra-dependency-foo',
+                    'extra-dependency-baz',
+                ],
+            ],
+        ]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $config = $this->prophesize(Config::class);
+        $config->get('sort-packages')->willReturn(true);
+        $config->get(Argument::any())->willReturn(null);
+
+        $link = $this->prophesize(Link::class);
+        $link->getTarget()->willReturn('extra-dependency-bar');
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $rootPackage->getRequires()->willReturn(['extra-dependency-foo' => $link]);
+        $rootPackage->getDevRequires()->willReturn([]);
+        $rootPackage->setRequires(Argument::any())->shouldNotBeCalled();
+        $rootPackage->getMinimumStability()->willReturn('stable');
+
+        $this->composer->getPackage()->willReturn($rootPackage);
+        $this->composer->getConfig()->willReturn($config->reveal());
+
+        $this->io->isInteractive()->willReturn(true)->shouldBeCalledTimes(1);
+        $this->io
+            ->askAndValidate(Argument::any(), Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+    }
+
+    public function testDependencyOrWrongDefinitionThrowsException()
+    {
+        /** @var PackageInterface|ObjectProphecy $package */
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/component');
+        $package->getExtra()->willReturn([
+            'dependency-or' => [
+                'extra-dependency-foo',
+                'extra-dependency-baz',
+            ],
+        ]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $config = $this->prophesize(Config::class);
+        $config->get('sort-packages')->willReturn(true);
+        $config->get(Argument::any())->willReturn(null);
+
+        $link = $this->prophesize(Link::class);
+        $link->getTarget()->willReturn('extra-dependency-bar');
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $rootPackage->getRequires()->willReturn(['extra-dependency-foo' => $link]);
+        $rootPackage->getDevRequires()->willReturn([]);
+        $rootPackage->setRequires(Argument::any())->shouldNotBeCalled();
+        $rootPackage->getMinimumStability()->willReturn('stable');
+
+        $this->composer->getPackage()->willReturn($rootPackage);
+        $this->composer->getConfig()->willReturn($config->reveal());
+
+        $this->io->isInteractive()->willReturn(true)->shouldBeCalledTimes(1);
+        $this->io
+            ->askAndValidate(Argument::any(), Argument::any())
+            ->shouldNotBeCalled();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('You must provide at least two optional dependencies.');
+        $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+    }
+
+    public function testIntegrationHandleDependencyAndDependencyOr()
+    {
+        /** @var PackageInterface|ObjectProphecy $package */
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/component');
+        $package->getExtra()->willReturn([
+            'dependency' => [
+                'extra-package-required',
+            ],
+            'dependency-or' => [
+                'Choose something' => [
+                    'extra-choose-one',
+                    'extra-choose-two',
+                    'extra-choose-three',
+                ],
+            ],
+        ]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $config = $this->prophesize(Config::class);
+        $config->get('sort-packages')->willReturn(true);
+        $config->get(Argument::any())->willReturn(null);
+
+        $rootPackage = $this->prophesize(RootPackageInterface::class);
+        $rootPackage->getRequires()->willReturn([]);
+        $rootPackage->getDevRequires()->willReturn([]);
+        $rootPackage->setRequires(Argument::that(function (array $arguments) {
+            if (count($arguments) !== 2) {
+                return false;
+            }
+
+            if (! $this->assertSetRequiresArgument('extra-package-required', '3.9.1', $arguments)) {
+                return false;
+            }
+
+            if (! $this->assertSetRequiresArgument('extra-choose-two', '2.1.5', $arguments)) {
+                return false;
+            }
+
+            return true;
+        }))->shouldBeCalled();
+        $rootPackage->getMinimumStability()->willReturn('stable');
+
+        $this->composer->getPackage()->willReturn($rootPackage);
+        $this->composer->getConfig()->willReturn($config->reveal());
+
+        $this->io->isInteractive()->willReturn(true);
+        $this->io
+            ->askAndValidate(
+                Argument::that(function ($arg) {
+                    if (! is_array($arg)) {
+                        return false;
+                    }
+
+                    Assert::assertCount(4, $arg);
+                    Assert::assertSame('<question>Choose something</question>', $arg[0]);
+                    Assert::assertSame('[<comment>1</comment>] extra-choose-one', $arg[1]);
+                    Assert::assertSame('[<comment>2</comment>] extra-choose-two', $arg[2]);
+                    Assert::assertSame('[<comment>3</comment>] extra-choose-three', $arg[3]);
+
+                    return true;
+                }),
+                Argument::type('callable')
+            )
+            ->willReturn('extra-choose-two')
+            ->shouldBeCalledTimes(1);
+        $this->io
+            ->askAndValidate(
+                'Enter the version of <info>extra-package-required</info> to require'
+                    . ' (or leave blank to use the latest version): ',
+                Argument::type('callable')
+            )
+            ->willReturn(false)
+            ->shouldBeCalledTimes(1);
+        $this->io
+            ->askAndValidate(
+                'Enter the version of <info>extra-choose-two</info> to require'
+                    . ' (or leave blank to use the latest version): ',
+                Argument::type('callable')
+            )
+            ->willReturn(false)
+            ->shouldBeCalledTimes(1);
+
+        $this->io->write('<info>    Updating composer.json</info>')->shouldBeCalled();
+        $this->io->write('<info>Updating root package</info>')->shouldBeCalled();
+        $this->io->write('<info>    Running an update to install dependent packages</info>')->shouldBeCalled();
+        $this->io->write('Using version <info>3.9.1</info> for <info>extra-package-required</info>')->shouldBeCalled();
+        $this->io->write('Using version <info>2.1.5</info> for <info>extra-choose-two</info>')->shouldBeCalled();
+
+        $this->setUpComposerInstaller(['extra-package-required', 'extra-choose-two']);
+        $this->setUpComposerJson();
+
+        $versionSelector = $this->prophesize(VersionSelector::class);
+        $versionSelector->findBestCandidate('extra-package-required', null, null, 'stable')
+            ->willReturn($package->reveal())
+            ->shouldBeCalledTimes(1);
+        $versionSelector->findBestCandidate('extra-choose-two', null, null, 'stable')
+            ->willReturn($package->reveal())
+            ->shouldBeCalledTimes(1);
+        $versionSelector->findRecommendedRequireVersion($package->reveal())
+            ->willReturn('3.9.1', '2.1.5')
+            ->shouldBeCalledTimes(2);
+
+        $this->setUpVersionSelector($versionSelector->reveal());
+        $this->setUpPool();
+
+        $this->assertNull($this->plugin->onPostPackage($event->reveal()));
+
+        $json = file_get_contents(vfsStream::url('project/composer.json'));
+        $composer = json_decode($json, true);
+        $this->assertTrue(isset($composer['require']['extra-package-required']));
+        $this->assertSame('3.9.1', $composer['require']['extra-package-required']);
+        $this->assertTrue(isset($composer['require']['extra-choose-two']));
+        $this->assertSame('2.1.5', $composer['require']['extra-choose-two']);
+    }
+
+    private function assertSetRequiresArgument($name, $version, array $arguments)
+    {
+        if (! isset($arguments[$name])) {
+            return false;
+        }
+
+        $argument = $arguments[$name];
+
+        if (! $argument instanceof Link) {
+            return false;
+        }
+
+        if ($argument->getTarget() !== $name) {
+            return false;
+        }
+
+        if ($argument->getConstraint()->getPrettyString() !== $version) {
+            return false;
+        }
+
+        if ($argument->getDescription() !== 'requires') {
+            return false;
+        }
+
+        return true;
     }
 
     public function testComposerInstallerFactory()


### PR DESCRIPTION
New feature. Now we can define list of dependencies and give user a choice which one should be installed.
In case your library is compatible with many libraries, and you want force user to choose one of them and give them a list of supported libraries to choose. Configuration for this new feature is the following (`extra` section in `composer.json`):
```json
    "extra": {
        "dependency-or": {
            "Question": [
                "package/to-choose",
                "package/or-this",
                ...
            ]
        }
    }
```

And user on composer update will be prompted with "Question" and list of packages:
```
Question
  [0] package/to-choose
  [1] package/or-this
  Make your selection: ...
```

User will be prompted only when none of these packages are not installed. If there is at least one package installed or defined in root composer user will be not prompted.

/cc @basz @weierophinney